### PR TITLE
Update go-jose module

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ go get github.com/s12v/go-jwks@v0.2.1
 
 ## Dependencies
 
- * `github.com/square/go-jose` - JWT library
+ * `github.com/go-jose/go-jose` - JWT library
  * `github.com/patrickmn/go-cache` - default in-memory cache
 
 ## Example
@@ -29,7 +29,7 @@ import (
 	"time"
 
 	"github.com/s12v/go-jwks"
-	"github.com/square/go-jose"
+	"gopkg.in/go-jose/go-jose.v2"
 )
 
 func main() {

--- a/client.go
+++ b/client.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"golang.org/x/sync/semaphore"
-	"gopkg.in/square/go-jose.v2"
+	"gopkg.in/go-jose/go-jose.v2"
 )
 
 type JWKSClient interface {

--- a/client_mock.go
+++ b/client_mock.go
@@ -2,7 +2,8 @@ package jwks
 
 import (
 	"context"
-	"gopkg.in/square/go-jose.v2"
+
+	"gopkg.in/go-jose/go-jose.v2"
 )
 
 type jWKSClientMock struct {

--- a/client_test.go
+++ b/client_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"gopkg.in/square/go-jose.v2"
+	"gopkg.in/go-jose/go-jose.v2"
 )
 
 func TestJWKSClient_GetKey(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/s12v/go-jwks
+module github.com/adrifern48/go-jwks
 
 go 1.12
 
@@ -9,5 +9,5 @@ require (
 	golang.org/x/crypto v0.0.0-20180621125126-a49355c7e3f8 // indirect
 	golang.org/x/net v0.0.0-20180729183719-c4299a1a0d85 // indirect
 	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f
-	gopkg.in/square/go-jose.v2 v2.6.0
+	gopkg.in/go-jose/go-jose.v2 v2.6.3
 )

--- a/go.sum
+++ b/go.sum
@@ -19,7 +19,7 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IV
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/square/go-jose.v2 v2.6.0 h1:NGk74WTnPKBNUhNzQX7PYcTLUjoq7mzKk2OKbvwk2iI=
-gopkg.in/square/go-jose.v2 v2.6.0/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
+gopkg.in/go-jose/go-jose.v2 v2.6.3 h1:nt80fvSDlhKWQgSWyHyy5CfmlQr+asih51R8PTWNKKs=
+gopkg.in/go-jose/go-jose.v2 v2.6.3/go.mod h1:zzZDPkNNw/c9IE7Z9jr11mBZQhKQTMzoEEIoEdZlFBI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/source.go
+++ b/source.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"gopkg.in/square/go-jose.v2"
 	"net/http"
+
+	"gopkg.in/go-jose/go-jose.v2"
 )
 
 type JWKSSource interface {

--- a/source_dummy.go
+++ b/source_dummy.go
@@ -2,7 +2,8 @@ package jwks
 
 import (
 	"context"
-	"gopkg.in/square/go-jose.v2"
+
+	"gopkg.in/go-jose/go-jose.v2"
 )
 
 type DummySource struct {


### PR DESCRIPTION
[square/go-jose](https://github.com/square/go-jose) is deprecated and has moved to [go-jose/go-jose](https://github.com/go-jose/go-jose)

Fixes issue: https://github.com/s12v/go-jwks/issues/17